### PR TITLE
feat: Standardization JSDoc and Type Definitions (Issue #12)

### DIFF
--- a/src/core/store.js
+++ b/src/core/store.js
@@ -1,19 +1,27 @@
 import { createContext } from "@lit/context";
 import { Signal } from "@lit-labs/signals";
 
-/** @typedef {import('../types/game.d.js').HotSwitchState} HotSwitchState */
+/**
+ * @typedef {import('../types/game.d.js').HotSwitchState} HotSwitchState
+ */
 
 /**
  * GameStore - Centralized state management for Legacy's End
  */
 export class GameStore {
 	constructor() {
+		/** @type {HeroStore} */
 		this.hero = new HeroStore();
+		/** @type {QuestStore} */
 		this.quest = new QuestStore();
+		/** @type {WorldStore} */
 		this.world = new WorldStore();
 	}
 }
 
+/**
+ * @implements {HeroState}
+ */
 class HeroStore {
 	constructor() {
 		this.pos = new Signal.State({ x: 50, y: 15 });
@@ -54,6 +62,9 @@ class HeroStore {
 	}
 }
 
+/**
+ * @implements {QuestState}
+ */
 class QuestStore {
 	constructor() {
 		this.hasCollectedItem = new Signal.State(false);
@@ -138,6 +149,9 @@ class QuestStore {
 	}
 }
 
+/**
+ * @implements {WorldState}
+ */
 class WorldStore {
 	constructor() {
 		this.isPaused = new Signal.State(false);

--- a/src/services/storage-service.js
+++ b/src/services/storage-service.js
@@ -1,7 +1,5 @@
 /**
- * @typedef {import('../types/services.d.js').ILoggerService} ILoggerService
- * @typedef {import('../types/services.d.js').IStorageAdapter} IStorageAdapter
- * @typedef {import('../types/common.d.js').JSONSerializable} JSONSerializable
+ * LocalStorageAdapter
  */
 
 /**

--- a/src/types/index.d.js
+++ b/src/types/index.d.js
@@ -1,0 +1,73 @@
+/**
+ * @template T, E
+ * @typedef {{ ok: true, value: T } | { ok: false, error: E }} Result
+ */
+
+/**
+ * @typedef {Object} AppError
+ * @property {string} message - Error message
+ * @property {string} code - Error code
+ * @property {any} [details] - Optional error details
+ */
+
+/**
+ * @typedef {import('@lit-labs/signals').Signal.State<T>} SignalState<T>
+ * @template T
+ */
+
+/**
+ * @typedef {Object} GameState
+ * @property {HeroState} hero
+ * @property {QuestState} quest
+ * @property {WorldState} world
+ */
+
+/**
+ * @typedef {Object} HeroState
+ * @property {SignalState<{x: number, y: number}>} pos
+ * @property {SignalState<import('./game.d.js').HotSwitchState>} hotSwitchState
+ * @property {SignalState<boolean>} isEvolving
+ * @property {SignalState<string>} imageSrc
+ */
+
+/**
+ * @typedef {Object} QuestState
+ * @property {SignalState<boolean>} hasCollectedItem
+ * @property {SignalState<boolean>} isRewardCollected
+ * @property {SignalState<boolean>} isQuestCompleted
+ * @property {SignalState<string|null>} lockedMessage
+ * @property {SignalState<number>} currentChapterNumber
+ * @property {SignalState<number>} totalChapters
+ * @property {SignalState<string | import('lit').TemplateResult>} levelTitle
+ * @property {SignalState<string | import('lit').TemplateResult>} questTitle
+ * @property {SignalState<string|null>} currentChapterId
+ */
+
+/**
+ * @typedef {Object} ILoggerService
+ * @property {(message: string, ...args: any[]) => void} error
+ * @property {(message: string, ...args: any[]) => void} warn
+ * @property {(message: string, ...args: any[]) => void} info
+ * @property {(message: string, ...args: any[]) => void} debug
+ */
+
+/**
+ * @typedef {string | number | boolean | null | { [key: string]: any } | any[]} JSONSerializable
+ */
+
+/**
+ * @typedef {Object} IStorageAdapter
+ * @property {(key: string) => JSONSerializable | null} getItem
+ * @property {(key: string, value: JSONSerializable) => void} setItem
+ * @property {(key: string) => void} removeItem
+ * @property {() => void} clear
+ */
+
+/**
+ * @typedef {Object} WorldState
+ * @property {SignalState<boolean>} isPaused
+ * @property {SignalState<boolean>} showDialog
+ * @property {SignalState<string>} currentDialogText
+ * @property {SignalState<string>} nextDialogText
+ * @property {SignalState<number>} currentSlideIndex
+ */


### PR DESCRIPTION
## Summary
This PR addresses **Issue #12** by standardizing JSDoc annotations and type definitions across the codebase to ensure better type safety and documentation.

## Changes
-   **Configuration**: Removed redundant `jsconfig.json` as `tsconfig.json` already handles JS type checking.
-   **Global Types**: Created `src/types/index.d.js` to define global types (`GameState`, `HeroState`, etc.) and utility types (`Result`, `AppError`).
-   **JSDoc Updates**:
    -   Updated `src/core/store.js` to implement global state interfaces.
    -   Updated `src/services/storage-service.js` to use global type definitions.
    -   Fixed circular dependency in `JSONSerializable` type.

## Verification
-   `npm run lint:tsc`: Passed successfully (verifies type correctness).
-   `npm test`: All tests passed.
-   `npm run e2e`: All E2E tests passed.