### PR TITLE
feat: implement Result Pattern and error types

### DIFF
--- a/src/core/errors.js
+++ b/src/core/errors.js
@@ -41,3 +41,121 @@ export class NotFoundError extends AppError {
 		super(message, code || "NOT_FOUND");
 	}
 }
+
+/**
+ * For invalid input.
+ */
+export class ValidationError extends AppError {
+	/**
+	 * @param {string} message
+	 * @param {string} [code]
+	 */
+	constructor(message, code) {
+		super(message, code || "VALIDATION_ERROR");
+	}
+}
+
+/**
+ * Result Pattern implementation for type-safe error handling.
+ * @template T - Success type
+ * @template E - Error type (defaults to AppError)
+ */
+export class Result {
+	/** @type {T | null} */
+	#value;
+	/** @type {E | null} */
+	#error;
+	/** @type {boolean} */
+	#ok;
+
+	/**
+	 * @param {T | null} value
+	 * @param {E | null} error
+	 * @param {boolean} ok
+	 */
+	constructor(value, error, ok) {
+		this.#value = value;
+		this.#error = error;
+		this.#ok = ok;
+	}
+
+	/**
+	 * Creates a successful Result.
+	 * @template T
+	 * @param {T} value
+	 * @returns {Result<T, any>}
+	 */
+	static ok(value) {
+		return new Result(value, null, true);
+	}
+
+	/**
+	 * Creates a failed Result.
+	 * @template E
+	 * @param {E} error
+	 * @returns {Result<any, E>}
+	 */
+	static err(error) {
+		return new Result(null, error, false);
+	}
+
+	/** @returns {boolean} */
+	isOk() {
+		return this.#ok;
+	}
+
+	/** @returns {boolean} */
+	isErr() {
+		return !this.#ok;
+	}
+
+	/**
+	 * @returns {T}
+	 * @throws {Error} If Result is an error.
+	 */
+	get value() {
+		if (!this.#ok) {
+			throw new Error(
+				"Cannot get value from an Error Result. Use isOk() first.",
+			);
+		}
+		return /** @type {T} */ (this.#value);
+	}
+
+	/**
+	 * @returns {E}
+	 * @throws {Error} If Result is a success.
+	 */
+	get error() {
+		if (this.#ok) {
+			throw new Error(
+				"Cannot get error from a Success Result. Use isErr() first.",
+			);
+		}
+		return /** @type {E} */ (this.#error);
+	}
+
+	/**
+	 * @template U
+	 * @param {(value: T) => U} fn
+	 * @returns {Result<U, E>}
+	 */
+	map(fn) {
+		if (this.#ok) {
+			return Result.ok(fn(/** @type {T} */ (this.#value)));
+		}
+		return Result.err(/** @type {E} */ (this.#error));
+	}
+
+	/**
+	 * @template F
+	 * @param {(error: E) => F} fn
+	 * @returns {Result<T, F>}
+	 */
+	mapErr(fn) {
+		if (!this.#ok) {
+			return Result.err(fn(/** @type {E} */ (this.#error)));
+		}
+		return Result.ok(/** @type {T} */ (this.#value));
+	}
+}

--- a/src/core/errors.test.js
+++ b/src/core/errors.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+	AppError,
+	DomainError,
+	NotFoundError,
+	Result,
+	ValidationError,
+} from "./errors.js";
+
+describe("Errors", () => {
+	it("should create AppError with default code", () => {
+		const error = new AppError("Message");
+		expect(error.message).toBe("Message");
+		expect(error.code).toBe("INTERNAL_ERROR");
+		expect(error.name).toBe("AppError");
+	});
+
+	it("should create DomainError with default code", () => {
+		const error = new DomainError("Domain logic violated");
+		expect(error.message).toBe("Domain logic violated");
+		expect(error.code).toBe("DOMAIN_ERROR");
+		expect(error.name).toBe("DomainError");
+	});
+
+	it("should create NotFoundError with default code", () => {
+		const error = new NotFoundError("Resource missing");
+		expect(error.message).toBe("Resource missing");
+		expect(error.code).toBe("NOT_FOUND");
+		expect(error.name).toBe("NotFoundError");
+	});
+
+	it("should create ValidationError with default code", () => {
+		const error = new ValidationError("Invalid input");
+		expect(error.message).toBe("Invalid input");
+		expect(error.code).toBe("VALIDATION_ERROR");
+		expect(error.name).toBe("ValidationError");
+	});
+});
+
+describe("Result Pattern", () => {
+	it("should create a successful result", () => {
+		const result = Result.ok("success");
+		expect(result.isOk()).toBe(true);
+		expect(result.isErr()).toBe(false);
+		expect(result.value).toBe("success");
+	});
+
+	it("should create an error result", () => {
+		const error = new AppError("Fail");
+		const result = Result.err(error);
+		expect(result.isOk()).toBe(false);
+		expect(result.isErr()).toBe(true);
+		expect(result.error).toBe(error);
+	});
+
+	it("should throw when getting value from an error result", () => {
+		const result = Result.err(new Error("Fail"));
+		expect(() => result.value).toThrow("Cannot get value from an Error Result");
+	});
+
+	it("should throw when getting error from a success result", () => {
+		const result = Result.ok("Success");
+		expect(() => result.error).toThrow(
+			"Cannot get error from a Success Result",
+		);
+	});
+
+	it("should map success value", () => {
+		const result = Result.ok(10);
+		const mapped = result.map((n) => n * 2);
+		expect(mapped.value).toBe(20);
+	});
+
+	it("should not map error result", () => {
+		const result = Result.err("fail");
+		const mapped = result.map((n) => n * 2);
+		expect(mapped.isErr()).toBe(true);
+		expect(mapped.error).toBe("fail");
+	});
+
+	it("should map error value", () => {
+		const result = Result.err("fail");
+		const mapped = result.mapErr((e) => e.toUpperCase());
+		expect(mapped.error).toBe("FAIL");
+	});
+
+	it("should not mapErr on success result", () => {
+		const result = Result.ok("success");
+		const mapped = result.mapErr((e) => e.toUpperCase());
+		expect(mapped.isOk()).toBe(true);
+		expect(mapped.value).toBe("success");
+	});
+});


### PR DESCRIPTION
Resolves #397. This PR introduces the Result Pattern for type-safe error handling and defines base error types in src/core/errors.js.